### PR TITLE
Update Program.cs

### DIFF
--- a/PersonatorConsumerDotnet/Program.cs
+++ b/PersonatorConsumerDotnet/Program.cs
@@ -110,17 +110,13 @@ namespace PersonatorConsumerDotnet
       
       Console.WriteLine("API Call: ");
       string APICall = Path.Combine(baseServiceUrl, requestQuery);
-      for (int i = 0; i < APICall.Length; i += 70)
-      {
-        try
-        {
-          Console.WriteLine(APICall.Substring(i, 70));
-        }
-        catch
-        {
-          Console.WriteLine(APICall.Substring(i, APICall.Length - i));
-        }
-      }
+      Console.WriteLine(String.Join(
+                Environment.NewLine,
+                    Enumerable.Range(0, (int)Math.Ceiling((double)APICall.Length / 70 ))
+                    .Select(i => i * 70)
+                    .Select(i => APICall
+                    .Substring(i, Math.Min(70, APICall.Length - i)))
+                ));
 
       Console.WriteLine("\nAPI Response:");
       Console.WriteLine(prettyResponse);


### PR DESCRIPTION
The original uses a deliberately expected exception to format console output at 70 characters. This leaves an exception in the log that looks icky and may make people say "why is there an error here?"

```
https://personator.melissadata.net/v3/WEB/ContactVerify/doContactVerif
y?&id=[ISupposeIReallyShouldHideTheKeyInAPublicPostButTrustMe]&format=
json&act=check&a1=71%20gold%20city%20court&city=yellowknife&state=NT&p
Exception thrown: 'System.ArgumentOutOfRangeException' in System.Private.CoreLib.dll
ostal=x1a%203p6&cntry=CA
```

The proposed LINQ snippet does not cause an exception.

```
API Call: 
https://personator.melissadata.net/v3/WEB/ContactVerify/doContactVerif
y?&id=[ISupposeIReallyShouldHideTheKeyInAPublicPostButTrustMe]&format=
json&act=check&full=RICHARD%20KIDD&a1=27%20UNION%20ST&city=PICTON&stat
e=ON&postal=K0K%202T0&cntry=CA

API Response:
```